### PR TITLE
Specific the pod cluster env for xgboost rabit settup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.3+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/evanphx/json-patch v4.0.0+incompatible h1:xregGRMLBeuRcwiOTHRCsPPuzCQlqhxUPbqdw+zNkLc=
 github.com/evanphx/json-patch v4.0.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -166,6 +167,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
@@ -208,6 +210,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/controller/xgboostjob/pod.go
+++ b/pkg/controller/xgboostjob/pod.go
@@ -96,8 +96,6 @@ func SetPodEnv(job interface{}, podTemplate *corev1.PodTemplateSpec, index strin
 
 	totalReplicas := computeTotalReplicas(xgboostjob)
 
-	println(totalReplicas)
-
 	for i := range podTemplate.Spec.Containers {
 		if len(podTemplate.Spec.Containers[i].Env) == 0 {
 			podTemplate.Spec.Containers[i].Env = make([]corev1.EnvVar, 0)

--- a/pkg/controller/xgboostjob/pod_test.go
+++ b/pkg/controller/xgboostjob/pod_test.go
@@ -1,0 +1,137 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xgboostjob
+
+import (
+	common "github.com/kubeflow/common/job_controller/api/v1"
+	"github.com/kubeflow/xgboost-operator/pkg/apis/xgboostjob/v1alpha1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func NewXGBoostJobWithMaster(worker int) *v1alpha1.XGBoostJob {
+	job := NewXGoostJob(worker)
+	master := int32(1)
+	masterReplicaSpec := &common.ReplicaSpec{
+		Replicas: &master,
+		Template: NewXGBoostReplicaSpecTemplate(),
+	}
+	job.Spec.XGBReplicaSpecs[common.ReplicaType(v1alpha1.XGBoostReplicaTypeMaster)] = masterReplicaSpec
+	return job
+}
+
+func NewXGoostJob(worker int) *v1alpha1.XGBoostJob {
+
+	job := &v1alpha1.XGBoostJob{
+		TypeMeta: metav1.TypeMeta{
+			Kind: v1alpha1.Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-xgboostjob",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.XGBoostJobSpec{
+			XGBReplicaSpecs: make(map[common.ReplicaType]*common.ReplicaSpec),
+		},
+	}
+
+	if worker > 0 {
+		worker := int32(worker)
+		workerReplicaSpec := &common.ReplicaSpec{
+			Replicas: &worker,
+			Template: NewXGBoostReplicaSpecTemplate(),
+		}
+		job.Spec.XGBReplicaSpecs[common.ReplicaType(v1alpha1.XGBoostReplicaTypeWorker)] = workerReplicaSpec
+	}
+
+	return job
+}
+
+func NewXGBoostReplicaSpecTemplate() v1.PodTemplateSpec {
+	return v1.PodTemplateSpec{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{
+					Name:  v1alpha1.DefaultContainerName,
+					Image: "test-image-for-kubeflow-pytorch-operator:latest",
+					Args:  []string{"Fake", "Fake"},
+					Ports: []v1.ContainerPort{
+						v1.ContainerPort{
+							Name:          v1alpha1.DefaultContainerPortName,
+							ContainerPort: v1alpha1.DefaultPort,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestClusterSpec(t *testing.T) {
+	type tc struct {
+		job                 *v1alpha1.XGBoostJob
+		rt                  v1alpha1.XGBoostJobReplicaType
+		index               string
+		expectedClusterSpec map[string]string
+	}
+	testCase := []tc{
+		tc{
+			job:                 NewXGBoostJobWithMaster(0),
+			rt:                  v1alpha1.XGBoostReplicaTypeMaster,
+			index:               "0",
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "1", "MASTER_PORT": "9999", "RANK": "0", "MASTER_ADDR": "test-xgboostjob-master-0"},
+		},
+		tc{
+			job:                 NewXGBoostJobWithMaster(1),
+			rt:                  v1alpha1.XGBoostReplicaTypeMaster,
+			index:               "1",
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "2", "MASTER_PORT": "9999", "RANK": "1", "MASTER_ADDR": "test-xgboostjob-master-0"},
+		},
+		tc{
+			job:                 NewXGBoostJobWithMaster(2),
+			rt:                  v1alpha1.XGBoostReplicaTypeMaster,
+			index:               "0",
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "0", "MASTER_ADDR": "test-xgboostjob-master-0"},
+		},
+		tc{
+			job:                 NewXGBoostJobWithMaster(2),
+			rt:                  v1alpha1.XGBoostReplicaTypeWorker,
+			index:               "1",
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "1", "MASTER_ADDR": "test-xgboostjob-master-0"},
+		},
+		tc{
+			job:                 NewXGBoostJobWithMaster(2),
+			rt:                  v1alpha1.XGBoostReplicaTypeWorker,
+			index:               "1",
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "1", "MASTER_ADDR": "test-xgboostjob-master-0"},
+		},
+	}
+	for _, c := range testCase {
+		demoTemplateSpec := c.job.Spec.XGBReplicaSpecs[common.ReplicaType(c.rt)].Template
+		if err := SetPodEnv(c.job, &demoTemplateSpec, c.index); err != nil {
+			t.Errorf("Failed to set cluster spec: %v", err)
+		}
+		actual := demoTemplateSpec.Spec.Containers[0].Env
+		for _, env := range actual {
+			if val, ok := c.expectedClusterSpec[env.Name]; ok {
+				if val != env.Value {
+					t.Errorf("For name %s Got %s. Expected %s ", env.Name, env.Value, c.expectedClusterSpec[env.Name])
+				}
+			}
+		}
+	}
+}

--- a/pkg/controller/xgboostjob/pod_test.go
+++ b/pkg/controller/xgboostjob/pod_test.go
@@ -67,7 +67,7 @@ func NewXGBoostReplicaSpecTemplate() v1.PodTemplateSpec {
 			Containers: []v1.Container{
 				v1.Container{
 					Name:  v1alpha1.DefaultContainerName,
-					Image: "test-image-for-kubeflow-pytorch-operator:latest",
+					Image: "test-image-for-kubeflow-xgboost-operator:latest",
 					Args:  []string{"Fake", "Fake"},
 					Ports: []v1.ContainerPort{
 						v1.ContainerPort{

--- a/pkg/controller/xgboostjob/util.go
+++ b/pkg/controller/xgboostjob/util.go
@@ -54,7 +54,7 @@ func computeMasterAddr(jobName, rtype, index string) string {
 	return strings.Replace(n, "/", "-", -1)
 }
 
-// GetPortFromPyTorchJob gets the port of pytorch container.
+// GetPortFromXGBoostJob gets the port of xgboost container.
 func GetPortFromXGBoostJob(job *v1alpha1.XGBoostJob, rtype v1alpha1.XGBoostJobReplicaType) (int32, error) {
 	containers := job.Spec.XGBReplicaSpecs[common.ReplicaType(rtype)].Template.Spec.Containers
 	for _, container := range containers {

--- a/pkg/controller/xgboostjob/xgboostjob_controller.go
+++ b/pkg/controller/xgboostjob/xgboostjob_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeflow/xgboost-operator/pkg/apis/xgboostjob/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -229,10 +230,5 @@ func (r *ReconcileXGBoostJob) IsMasterRole(replicas map[v1.ReplicaType]*v1.Repli
 
 // SetClusterSpec sets the cluster spec for the pod
 func (r *ReconcileXGBoostJob) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, index string) error {
-	_, ok := job.(*v1alpha1.XGBoostJob)
-	if !ok {
-		return fmt.Errorf("%+v is not a type of XGBoostJob", job)
-	}
-	// TODO to implement this for the next pr
-	return nil
+	return SetPodEnv(job, podTemplate, index)
 }


### PR DESCRIPTION
## what is proposed in this PR ?
setup the cluster env for the pod, and export this information for xgboost rabit settup. 

## how to test this PR
provide the pod_test.go, and test passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/xgboost-operator/23)
<!-- Reviewable:end -->
