### PR TITLE
Hard coded endpoint address for OSS is removed

### DIFF
--- a/config/samples/xgboost-dist/README.md
+++ b/config/samples/xgboost-dist/README.md
@@ -25,7 +25,9 @@ There are two yaml files to setup distributed XGBoost computation runtime.
 For training job, you could configure xgboostjob_v1alpha1_iris_predict.yaml. 
 Note, we use [OSS](https://www.alibabacloud.com/product/oss) to store the trained model, 
 thus, you need to specify the OSS parameter in the yaml file. Therefore, remember to fill the OSS parameter in the yaml file. 
-The oss parameter includes the account and key information. 
+The oss parameter includes the account information such as access_id, access_key, access_bucket and endpoint. 
+For Eg:
+--oss_param=endpoint:http://oss-ap-south-1.aliyuncs.com,access_id:XXXXXXXXXXX,access_key:XXXXXXXXXXXXXXXXXXX,access_bucket:XXXXXX
 Similarly, xgboostjob_v1alpha1_iris_predict.yaml is used to configure XGBoost job batch prediction. 
 
 **Start the distributed XGBoost train**

--- a/config/samples/xgboost-dist/utils.py
+++ b/config/samples/xgboost-dist/utils.py
@@ -274,17 +274,17 @@ def read_model_from_oss(kw):
 def parse_parameters(input, splitter_between, splitter_in):
     """
     helper function parse the input parameter
-    :param input: the string of configuration like key-value paris
+    :param input: the string of configuration like key-value pairs
     :param splitter_between: the splitter between config for input string
     :param splitter_in: the splitter inside config for input string
     :return: key-value pair configuration
     """
 
-    ky_paris = input.split(splitter_between)
+    ky_pairs = input.split(splitter_between)
 
     confs = {}
 
-    for kv in ky_paris:
+    for kv in ky_pairs:
         conf = kv.split(splitter_in)
         key = conf[0].strip(" ")
         if key == "objective" or key == "endpoint":

--- a/config/samples/xgboost-dist/utils.py
+++ b/config/samples/xgboost-dist/utils.py
@@ -141,8 +141,7 @@ def dump_model(model, type, model_path, args):
             if oss_param is None:
                 raise Exception("Please config oss parameter to store model")
 
-            oss_param['path'] = args.model_path
-            oss_param['endpoint'] = 'http://oss-cn-hangzhou-zmf.aliyuncs.com'
+            oss_param['path'] = args.model_path            
             dump_model_to_oss(oss_param, model)
             logging.info("Dump model into oss place %s", args.model_path)
 
@@ -171,8 +170,7 @@ def read_model(type, model_path, args):
             raise Exception("Please config oss to read model")
             return False
 
-        oss_param['path'] = args.model_path
-        oss_param['endpoint'] = 'http://oss-cn-hangzhou-zmf.aliyuncs.com'
+        oss_param['path'] = args.model_path        
 
         model = read_model_from_oss(oss_param)
         logging.info("read model from oss place %s", model_path)
@@ -289,7 +287,7 @@ def parse_parameters(input, splitter_between, splitter_in):
     for kv in ky_paris:
         conf = kv.split(splitter_in)
         key = conf[0].strip(" ")
-        if key == "objective":
+        if key == "endpoint":
             value = conf[1].strip("'") + ":" + conf[2].strip("'")
         else:
             value = conf[1]

--- a/config/samples/xgboost-dist/utils.py
+++ b/config/samples/xgboost-dist/utils.py
@@ -287,8 +287,8 @@ def parse_parameters(input, splitter_between, splitter_in):
     for kv in ky_paris:
         conf = kv.split(splitter_in)
         key = conf[0].strip(" ")
-        if key == "endpoint":
-            value = conf[1].strip("'") + ":" + conf[2].strip("'")
+        if key == "objective" or key == "endpoint":
+            value = conf[1].strip("'") + ":" + conf[2].strip("'")       
         else:
             value = conf[1]
 


### PR DESCRIPTION
Due to endpoint address is already set in .py(`oss_param['endpoint'] = 'http://oss-cn-hangzhou-zmf.aliyuncs.com'`) and not able to change via options if some other location OSS is used, hence removing hard coded value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/xgboost-operator/34)
<!-- Reviewable:end -->
