### PR TITLE
local_model_support: Supporting the local dump of the model in xgboost

### DIFF
--- a/config/samples/xgboost-dist/README.md
+++ b/config/samples/xgboost-dist/README.md
@@ -1,9 +1,9 @@
 ### Distributed XGBoost Job train and prediction
 
-This folder containers related files for distributed XGBoost training and prediction. In this demo,  
-[Iris Data Set](https://archive.ics.uci.edu/ml/datasets/iris) is a well known multi-class classification dataset. 
+This folder containers related files for distributed XGBoost training and prediction. In this demo,
+[Iris Data Set](https://archive.ics.uci.edu/ml/datasets/iris) is a well known multi-class classification dataset.
 Thus, in this demo, distributed XGBoost job is able to do multi-class classification problem. Meanwhile,
-User can extend provided data reader to read data from distributed data storage like HDFS, HBase or Hive etc. 
+User can extend provided data reader to read data from distributed data storage like HDFS, HBase or Hive etc.
 
 
 **Build image**
@@ -21,18 +21,30 @@ docker push kubeflow/xgboost-dist-iris-test:1.0 ./
 
 **Configure the job runtime via Yaml file**
 
-There are two yaml files to setup distributed XGBoost computation runtime. 
-For training job, you could configure xgboostjob_v1alpha1_iris_predict.yaml. 
-Note, we use [OSS](https://www.alibabacloud.com/product/oss) to store the trained model, 
-thus, you need to specify the OSS parameter in the yaml file. Therefore, remember to fill the OSS parameter in the yaml file. 
-The oss parameter includes the account information such as access_id, access_key, access_bucket and endpoint. 
+The following files are available to setup distributed XGBoost computation runtime
+ 
+To store the model in OSS:
+
+* xgboostjob_v1alpha1_iris_train.yaml 
+* xgboostjob_v1alpha1_iris_predict.yaml
+
+To store the model in local path:
+
+* xgboostjob_v1alpha1_iris_train_local.yaml
+* xgboostjob_v1alpha1_iris_predict_local.yaml
+
+For training jobs in OSS , you could configure xgboostjob_v1alpha1_iris_train.yaml and xgboostjob_v1alpha1_iris_predict.yaml
+Note, we use [OSS](https://www.alibabacloud.com/product/oss) to store the trained model,
+thus, you need to specify the OSS parameter in the yaml file. Therefore, remember to fill the OSS parameter in xgboostjob_v1alpha1_iris_train.yaml and xgboostjob_v1alpha1_iris_predict.yaml file.
+The oss parameter includes the account information such as access_id, access_key, access_bucket and endpoint.
 For Eg:
 --oss_param=endpoint:http://oss-ap-south-1.aliyuncs.com,access_id:XXXXXXXXXXX,access_key:XXXXXXXXXXXXXXXXXXX,access_bucket:XXXXXX
-Similarly, xgboostjob_v1alpha1_iris_predict.yaml is used to configure XGBoost job batch prediction. 
+Similarly, xgboostjob_v1alpha1_iris_predict.yaml is used to configure XGBoost job batch prediction.
 
-**Start the distributed XGBoost train**
+
+**Start the distributed XGBoost train to store the model in OSS**
 ```
-kubectl create -f xgboostjob_v1alpha1_iris_train.yaml 
+kubectl create -f xgboostjob_v1alpha1_iris_train.yaml
 ```
 
 **Look at the train job status**
@@ -247,4 +259,248 @@ Events:
   Normal  ExitedWithCode           38s (x3 over 40s)  xgboostjob-operator  Pod: default.xgboost-dist-iris-test-predict-worker-0 exited with code 0
   Normal  ExitedWithCode           38s                xgboostjob-operator  Pod: default.xgboost-dist-iris-test-predict-master-0 exited with code 0
   Normal  XGBoostJobSucceeded      38s                xgboostjob-operator  XGBoostJob xgboost-dist-iris-test-predict is successfully completed.
+```
+
+**Start the distributed XGBoost train to store the model locally**
+
+Before proceeding with training we will create a PVC to store the model trained.
+Creating pvc : 
+create a yaml file with the below content 
+pvc.yaml
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: xgboostlocal
+spec:
+  storageClassName: glusterfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+```
+```
+kubectl create -f pvc.yaml
+```
+Note: 
+
+* Please use the storage class which supports ReadWriteMany. The example yaml above uses glusterfs
+
+* Mention model_storage_type=local and model_path accordingly( In the example /tmp/xgboost_model/2 is used ) in xgboostjob_v1alpha1_iris_train_local.yaml and xgboostjob_v1alpha1_iris_predict_local.yaml"
+
+Now start the distributed XGBoost train. 
+```
+kubectl create -f xgboostjob_v1alpha1_iris_train_local.yaml
+```
+
+**Look at the train job status**
+```
+ kubectl get -o yaml XGBoostJob/xgboost-dist-iris-test-train-local
+ ```
+ Here is a sample output when the job is finished. The output log like this
+```
+
+apiVersion: xgboostjob.kubeflow.org/v1alpha1
+kind: XGBoostJob
+metadata:
+  creationTimestamp: "2019-09-17T05:36:01Z"
+  generation: 7
+  name: xgboost-dist-iris-test-train_local
+  namespace: default
+  resourceVersion: "8919366"
+  selfLink: /apis/xgboostjob.kubeflow.org/v1alpha1/namespaces/default/xgboostjobs/xgboost-dist-iris-test-train_local
+  uid: 08f85fad-d90d-11e9-aca1-fa163ea13108
+spec:
+  RunPolicy:
+    cleanPodPolicy: None
+  xgbReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - args:
+            - --job_type=Train
+            - --xgboost_parameter=objective:multi:softprob,num_class:3
+            - --n_estimators=10
+            - --learning_rate=0.1
+            - --model_path=/tmp/xgboost_model/2
+            - --model_storage_type=local
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            imagePullPolicy: Always
+            name: xgboostjob
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/xgboost_model
+              name: task-pv-storage
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - args:
+            - --job_type=Train
+            - --xgboost_parameter="objective:multi:softprob,num_class:3"
+            - --n_estimators=10
+            - --learning_rate=0.1
+            - --model_path=/tmp/xgboost_model/2
+            - --model_storage_type=local
+            image: bcmt-registry:5000/kubeflow/xgboost-dist-iris-test:1.0
+            imagePullPolicy: Always
+            name: xgboostjob
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/xgboost_model
+              name: task-pv-storage
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+status:
+  completionTime: "2019-09-17T05:37:02Z"
+  conditions:
+  - lastTransitionTime: "2019-09-17T05:36:02Z"
+    lastUpdateTime: "2019-09-17T05:36:02Z"
+    message: xgboostJob xgboost-dist-iris-test-train_local is created.
+    reason: XGBoostJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-09-17T05:36:02Z"
+    lastUpdateTime: "2019-09-17T05:36:02Z"
+    message: XGBoostJob xgboost-dist-iris-test-train_local is running.
+    reason: XGBoostJobRunning
+    status: "False"
+    type: Running
+  - lastTransitionTime: "2019-09-17T05:37:02Z"
+    lastUpdateTime: "2019-09-17T05:37:02Z"
+    message: XGBoostJob xgboost-dist-iris-test-train_local is successfully completed.
+    reason: XGBoostJobSucceeded
+    status: "True"
+    type: Succeeded
+  replicaStatuses:
+    Master:
+      succeeded: 1
+    Worker:
+      succeeded: 2 
+ ```
+**Start the distributed XGBoost job predict**
+```
+kubectl create -f xgboostjob_v1alpha1_iris_predict_local.yaml
+```
+
+**Look at the batch predict job status**
+```
+ kubectl get -o yaml XGBoostJob/xgboost-dist-iris-test-predict-local
+ ```
+ Here is a sample output when the job is finished. The output log like this
+```
+apiVersion: xgboostjob.kubeflow.org/v1alpha1
+kind: XGBoostJob
+metadata:
+  creationTimestamp: "2019-09-17T06:33:38Z"
+  generation: 6
+  name: xgboost-dist-iris-test-predict_local
+  namespace: default
+  resourceVersion: "8976054"
+  selfLink: /apis/xgboostjob.kubeflow.org/v1alpha1/namespaces/default/xgboostjobs/xgboost-dist-iris-test-predict_local
+  uid: 151655b0-d915-11e9-aca1-fa163ea13108
+spec:
+  RunPolicy:
+    cleanPodPolicy: None
+  xgbReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - args:
+            - --job_type=Predict
+            - --model_path=/tmp/xgboost_model/2
+            - --model_storage_type=local
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            imagePullPolicy: Always
+            name: xgboostjob
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/xgboost_model
+              name: task-pv-storage
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - args:
+            - --job_type=Predict
+            - --model_path=/tmp/xgboost_model/2
+            - --model_storage_type=local
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            imagePullPolicy: Always
+            name: xgboostjob
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/xgboost_model
+              name: task-pv-storage
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+status:
+  completionTime: "2019-09-17T06:33:51Z"
+  conditions:
+  - lastTransitionTime: "2019-09-17T06:33:38Z"
+    lastUpdateTime: "2019-09-17T06:33:38Z"
+    message: xgboostJob xgboost-dist-iris-test-predict_local is created.
+    reason: XGBoostJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-09-17T06:33:38Z"
+    lastUpdateTime: "2019-09-17T06:33:38Z"
+    message: XGBoostJob xgboost-dist-iris-test-predict_local is running.
+    reason: XGBoostJobRunning
+    status: "False"
+    type: Running
+  - lastTransitionTime: "2019-09-17T06:33:51Z"
+    lastUpdateTime: "2019-09-17T06:33:51Z"
+    message: XGBoostJob xgboost-dist-iris-test-predict_local is successfully completed.
+    reason: XGBoostJobSucceeded
+    status: "True"
+    type: Succeeded
+  replicaStatuses:
+    Master:
+      succeeded: 1
+    Worker:
+      succeeded: 1
 ```

--- a/config/samples/xgboost-dist/main.py
+++ b/config/samples/xgboost-dist/main.py
@@ -20,6 +20,12 @@ from utils import dump_model
 
 def main(args):
 
+    model_storage_type = args.model_storage_type
+    if (model_storage_type == "local" or model_storage_type == "oss"):
+      print ( "The storage type is " + model_storage_type)
+    else:
+      raise Exception("Only supports storage types like local and OSS")
+
     if args.job_type == "Predict":
         logging.info("starting the predict job")
         predict(args)
@@ -30,7 +36,6 @@ def main(args):
 
         if model is not None:
             logging.info("finish the model training, and start to dump model ")
-            model_storage_type = args.model_storage_type
             model_path = args.model_path
             dump_model(model, model_storage_type, model_path, args)
 
@@ -75,7 +80,7 @@ if __name__ == '__main__':
           )
     parser.add_argument(
           '--model_storage_type',
-          help='place to stroge the model',
+          help='place to store the model',
           default="oss"
           )
     parser.add_argument(

--- a/config/samples/xgboost-dist/predict.py
+++ b/config/samples/xgboost-dist/predict.py
@@ -29,7 +29,8 @@ def predict(args):
     dmatrix, y_test = read_predict_data(rank, world_size, None)
 
     model_path = args.model_path
-    booster = read_model("oss", model_path, args)
+    storage_type = args.model_storage_type
+    booster = read_model(storage_type, model_path, args)
 
     preds = booster.predict(dmatrix)
 

--- a/config/samples/xgboost-dist/utils.py
+++ b/config/samples/xgboost-dist/utils.py
@@ -145,9 +145,6 @@ def dump_model(model, type, model_path, args):
             dump_model_to_oss(oss_param, model)
             logging.info("Dump model into oss place %s", args.model_path)
 
-        else:
-            raise Exception("Only support storage types like local and OSS")
-
     return True
 
 
@@ -174,9 +171,6 @@ def read_model(type, model_path, args):
 
         model = read_model_from_oss(oss_param)
         logging.info("read model from oss place %s", model_path)
-
-    else:
-        raise Exception("Only support storage types like local and OSS")
 
     return model
 

--- a/config/samples/xgboost-dist/xgboostjob_v1alpha1_iris_predict_local.yaml
+++ b/config/samples/xgboost-dist/xgboostjob_v1alpha1_iris_predict_local.yaml
@@ -1,0 +1,56 @@
+apiVersion: "xgboostjob.kubeflow.org/v1alpha1"
+kind: "XGBoostJob"
+metadata:
+  name: "xgboost-dist-iris-test-predict-local"
+spec:
+  xgbReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        apiVersion: v1
+        kind: Pod
+        spec:
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+          containers:
+          - name: xgboostjob
+            image: docker.io/merlintang/xgboost-dist-iris:1.1 
+            volumeMounts:
+              - name: task-pv-storage
+                mountPath: /tmp/xgboost_model
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+              - --job_type=Predict
+              - --model_path=/tmp/xgboost_model/2
+              - --model_storage_type=local
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        apiVersion: v1
+        kind: Pod
+        spec:
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+          containers:
+          - name: xgboostjob
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            volumeMounts:
+              - name: task-pv-storage
+                mountPath: /tmp/xgboost_model
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+             - --job_type=Predict
+             - --model_path=/tmp/xgboost_model/2
+             - --model_storage_type=local

--- a/config/samples/xgboost-dist/xgboostjob_v1alpha1_iris_train_local.yaml
+++ b/config/samples/xgboost-dist/xgboostjob_v1alpha1_iris_train_local.yaml
@@ -1,0 +1,62 @@
+apiVersion: "xgboostjob.kubeflow.org/v1alpha1"
+kind: "XGBoostJob"
+metadata:
+  name: "xgboost-dist-iris-test-train-local"
+spec:
+  xgbReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        apiVersion: v1
+        kind: Pod
+        spec:
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+          containers:
+          - name: xgboostjob
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            volumeMounts:
+              - name: task-pv-storage
+                mountPath: /tmp/xgboost_model
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+              - --job_type=Train
+              - --xgboost_parameter=objective:multi:softprob,num_class:3
+              - --n_estimators=10
+              - --learning_rate=0.1
+              - --model_path=/tmp/xgboost_model/2
+              - --model_storage_type=local
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        apiVersion: v1
+        kind: Pod
+        spec:
+          volumes:
+          - name: task-pv-storage
+            persistentVolumeClaim:
+              claimName: xgboostlocal
+          containers:
+          - name: xgboostjob
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            volumeMounts:
+              - name: task-pv-storage
+                mountPath: /tmp/xgboost_model
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+              - --job_type=Train
+              - --xgboost_parameter="objective:multi:softprob,num_class:3"
+              - --n_estimators=10
+              - --learning_rate=0.1
+              - --model_path=/tmp/xgboost_model/2
+              - --model_storage_type=local


### PR DESCRIPTION
The storage type was hard-coded as "OSS" which was restricting the predict job to fetch the trained model from the local path.
Changed and updated the README.md accordingly.
Also created the train and predict yaml files only for storing the model locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/xgboost-operator/36)
<!-- Reviewable:end -->
