### PR TITLE
xgboost operator manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kube
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /
+WORKDIR /root
 COPY --from=builder /go/src/github.com/kubeflow/xgboost-operator/manager .
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/root/manager"]

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,7 +31,9 @@ import (
 
 func main() {
 	var metricsAddr string
+	var mode string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&mode, "mode", "local", "The mode in which xgboost-operator to run")
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")

--- a/manifests/xgboost-operator/base/cluster-role-binding.yaml
+++ b/manifests/xgboost-operator/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/manifests/xgboost-operator/base/cluster-role.yaml
+++ b/manifests/xgboost-operator/base/cluster-role.yaml
@@ -1,0 +1,75 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - xgboostjob.kubeflow.org
+  resources:
+  - xgboostjobs
+  - xgboostjobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/manifests/xgboost-operator/base/crd.yaml
+++ b/manifests/xgboost-operator/base/crd.yaml
@@ -1,0 +1,127 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: xgboostjobs.xgboostjob.kubeflow.org
+spec:
+  group: xgboostjob.kubeflow.org
+  names:
+    kind: XGBoostJob
+    plural: xgboostjobs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            activeDeadlineSeconds:
+              description: Specifies the duration in seconds relative to the startTime
+                that the job may be active before the system tries to terminate it;
+                value must be positive integer.
+              format: int64
+              type: integer
+            backoffLimit:
+              description: Optional number of retries before marking this job failed.
+              format: int32
+              type: integer
+            cleanPodPolicy:
+              description: CleanPodPolicy defines the policy to kill pods after the
+                job completes. Default to Running.
+              type: string
+            schedulingPolicy:
+              description: SchedulingPolicy defines the policy related to scheduling,
+                e.g. gang-scheduling
+              properties:
+                minAvailable:
+                  format: int32
+                  type: integer
+              type: object
+            ttlSecondsAfterFinished:
+              description: TTLSecondsAfterFinished is the TTL to clean up jobs. It
+                may take extra ReconcilePeriod seconds for the cleanup, since reconcile
+                gets called periodically. Default to infinite.
+              format: int32
+              type: integer
+            xgbReplicaSpecs:
+              type: object
+          required:
+          - xgbReplicaSpecs
+          type: object
+        status:
+          properties:
+            completionTime:
+              description: Represents time when the job was completed. It is not guaranteed
+                to be set in happens-before order across separate operations. It is
+                represented in RFC3339 form and is in UTC.
+              format: date-time
+              type: string
+            conditions:
+              description: Conditions is an array of current observed job conditions.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of job condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            lastReconcileTime:
+              description: Represents last time when the job was reconciled. It is
+                not guaranteed to be set in happens-before order across separate operations.
+                It is represented in RFC3339 form and is in UTC.
+              format: date-time
+              type: string
+            replicaStatuses:
+              description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                specifies the status of each replica.
+              type: object
+            startTime:
+              description: Represents time when the job was acknowledged by the job
+                controller. It is not guaranteed to be set in happens-before order
+                across separate operations. It is represented in RFC3339 form and
+                is in UTC.
+              format: date-time
+              type: string
+          required:
+          - conditions
+          - replicaStatuses
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/xgboost-operator/base/deployment.yaml
+++ b/manifests/xgboost-operator/base/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    metadata:
+      labels:
+        app: xgboost-operator
+    spec:
+      containers:
+      - name: xgboost-operator
+        command:
+        - /root/manager
+        - -mode=in-cluster
+        image: gcr.io/kubeflow-images-public/xgboost-operator:v1.0
+        imagePullPolicy: Always
+      serviceAccountName: service-account

--- a/manifests/xgboost-operator/base/kustomization.yaml
+++ b/manifests/xgboost-operator/base/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- crd.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+namespace: kubeflow
+nameprefix: xgboost-operator-
+configMapGenerator:
+- name: parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+  - name: gcr.io/kubeflow-images-public/xgboost-operator
+    newName: gcr.io/kubeflow-images-public/xgboost-operator
+    newTag: 8e29825

--- a/manifests/xgboost-operator/base/params.yaml
+++ b/manifests/xgboost-operator/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment

--- a/manifests/xgboost-operator/base/service-account.yaml
+++ b/manifests/xgboost-operator/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/manifests/xgboost-operator/base/service.yaml
+++ b/manifests/xgboost-operator/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+  labels:
+    app: xgboost-operator
+spec:
+  type: ClusterIP
+  selector:
+    app: xgboost-operator 
+  ports:
+  - port: 443

--- a/manifests/xgboost-operator/overlays/application/application.yaml
+++ b/manifests/xgboost-operator/overlays/application/application.yaml
@@ -1,0 +1,40 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: xgboost-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: xgboost-operator
+      app.kubernetes.io/instance: xgboost-operator
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: xgboostjob
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.6
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: extensions/v1beta1
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: xgboostjob.kubeflow.org
+    kind: XGBoostJob
+  descriptor: 
+    type: xgboostjob
+    version: v1alpha1
+    description: XGBoost is an optimized distributed gradient boosting library designed to be highly efficient, flexible and portable
+    maintainers:
+    - name: Yuan Tang
+      email: terrytangyuan@gmail.com
+    - name: Hemantha kumara
+      email: mshemantha@gmail.com
+    owners:
+    - name: Yuan Tang
+      email: terrytangyuan@gmail.com
+    keywords:
+     - xgboost
+    links:
+    - description: About
+      url: "https://xgboost.ai/about"
+  addOwnerRef: true

--- a/manifests/xgboost-operator/overlays/application/kustomization.yaml
+++ b/manifests/xgboost-operator/overlays/application/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- application.yaml
+commonLabels:
+  app.kubernetes.io/name: xgboost-operator
+  app.kubernetes.io/instance: xgboost-operator
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/component: xgboostjob
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: v0.6
+


### PR DESCRIPTION
Resolves #31 

With this PR I have introduced new flag called -mode(local/in-cluster) 
```
1. in-cluster - To support running operator inside pod/container 
2. local - To support runing operator local(on k8s nodes)
```
To Support above mode, modified `main.go & xgboostjob_controller.go`

Added manifests directory which is having crd, deployment, rbacs and service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/xgboost-operator/39)
<!-- Reviewable:end -->
