### PR TITLE
For the worker rank, we should add the offset caused by the master re…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/markbates/inflect v1.0.4 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
-	github.com/onsi/gomega v1.5.0
+	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/petar/GoLLRB v0.0.0-20190514000832-33fb24c13b99 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
@@ -32,7 +32,7 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
-	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
+	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0 // indirect
 	golang.org/x/sys v0.0.0-20190529164535-6a60838ec259 // indirect
 	golang.org/x/text v0.3.2 // indirect
@@ -40,17 +40,17 @@ require (
 	google.golang.org/appengine v1.6.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
 	k8s.io/api v0.0.0-20181026184759-d1dc89ebaebe
-	k8s.io/apiextensions-apiserver v0.0.0-20181026191334-ba848ee89ca3
+	k8s.io/apiextensions-apiserver v0.0.0-20181026191334-ba848ee89ca3 // indirect
 	k8s.io/apimachinery v0.0.0-20181022183627-f71dbbc36e12
 	k8s.io/apiserver v0.0.0-20181026185746-f1e867e1a455 // indirect
 	k8s.io/client-go v0.0.0-20181004124242-1638f8970cef
-	k8s.io/code-generator v0.0.0-20180823001027-3dcf91f64f63
+	k8s.io/code-generator v0.0.0-20180823001027-3dcf91f64f63 // indirect
 	k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a // indirect
 	k8s.io/klog v0.3.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
 	k8s.io/kubernetes v1.12.2
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/controller-runtime v0.1.9
-	sigs.k8s.io/controller-tools v0.1.8
+	sigs.k8s.io/controller-tools v0.1.8 // indirect
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 )

--- a/pkg/controller/xgboostjob/pod_test.go
+++ b/pkg/controller/xgboostjob/pod_test.go
@@ -110,19 +110,19 @@ func TestClusterSpec(t *testing.T) {
 		tc{
 			job:                 NewXGBoostJobWithMaster(2),
 			rt:                  v1alpha1.XGBoostReplicaTypeWorker,
-			index:               "1",
+			index:               "0",
 			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "1", "MASTER_ADDR": "test-xgboostjob-master-0"},
 		},
 		tc{
 			job:                 NewXGBoostJobWithMaster(2),
 			rt:                  v1alpha1.XGBoostReplicaTypeWorker,
 			index:               "1",
-			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "1", "MASTER_ADDR": "test-xgboostjob-master-0"},
+			expectedClusterSpec: map[string]string{"WORLD_SIZE": "3", "MASTER_PORT": "9999", "RANK": "2", "MASTER_ADDR": "test-xgboostjob-master-0"},
 		},
 	}
 	for _, c := range testCase {
 		demoTemplateSpec := c.job.Spec.XGBReplicaSpecs[common.ReplicaType(c.rt)].Template
-		if err := SetPodEnv(c.job, &demoTemplateSpec, c.index); err != nil {
+		if err := SetPodEnv(c.job, &demoTemplateSpec, string(c.rt), c.index); err != nil {
 			t.Errorf("Failed to set cluster spec: %v", err)
 		}
 		actual := demoTemplateSpec.Spec.Containers[0].Env

--- a/pkg/controller/xgboostjob/xgboostjob_controller.go
+++ b/pkg/controller/xgboostjob/xgboostjob_controller.go
@@ -281,5 +281,5 @@ func (r *ReconcileXGBoostJob) IsMasterRole(replicas map[v1.ReplicaType]*v1.Repli
 
 // SetClusterSpec sets the cluster spec for the pod
 func (r *ReconcileXGBoostJob) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, index string) error {
-	return SetPodEnv(job, podTemplate, index)
+	return SetPodEnv(job, podTemplate, rtype, index)
 }


### PR DESCRIPTION
For the worker rank, we should add the offset caused by the master replicas. If not, the [worker-0](https://github.com/kubeflow/xgboost-operator/blob/master/config/samples/xgboost-dist/train.py#L35) start up with rank=0, and setup the tracker service, then it will not exit when the job is finished.