### PR TITLE
Fix typo of comment in apis.go

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -14,7 +14,7 @@ limitations under the License.
 */
 
 // Generate deepcopy for apis
-//go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
+// go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
 
 // Package apis contains Kubernetes API groups.
 package apis


### PR DESCRIPTION
Found a small typo of comment in pkg/apis/apis.go.