### PR TITLE
Skip create/delete logs for unrelated pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,22 +58,21 @@ make install
 make run 
 ``` 
 If the XGBoost Job operator can be installed into cluster, you can view the logs likes this 
-``` 
-INFO[0000] Update on create function xgboostjob-operator create object kubernetes 
-INFO[0000] Update on create function xgboostjob-operator create object kube-dns 
-INFO[0000] Update on create function xgboostjob-operator create object kubernetes-dashboard 
-INFO[0000] Update on create function xgboostjob-operator create object storage-provisioner 
-INFO[0000] Update on create function xgboostjob-operator create object kube-proxy-6l7mk 
-INFO[0000] Update on create function xgboostjob-operator create object coredns-fb8b8dccf-mfsdw 
-INFO[0000] Update on create function xgboostjob-operator create object coredns-fb8b8dccf-tx8nz 
-INFO[0000] Update on create function xgboostjob-operator create object etcd-minikube 
-INFO[0000] Update on create function xgboostjob-operator create object kube-addon-manager-minikube 
-INFO[0000] Update on create function xgboostjob-operator create object kube-apiserver-minikube 
-INFO[0000] Update on create function xgboostjob-operator create object kube-controller-manager-minikube 
-INFO[0000] Update on create function xgboostjob-operator create object kube-scheduler-minikube 
-INFO[0000] Update on create function xgboostjob-operator create object kubernetes-dashboard-79dd6bfc48-dvqzq 
-{"level":"info","ts":1561676117.843403,"logger":"kubebuilder.controller","msg":"Starting Controller","controller":"xgboostjob-controller"}
-{"level":"info","ts":1561676117.947829,"logger":"kubebuilder.controller","msg":"Starting workers","controller":"xgboostjob-controller","worker count":1}  
+```
+{"level":"info","ts":1589406873.090652,"logger":"entrypoint","msg":"setting up client for manager"}
+{"level":"info","ts":1589406873.0991302,"logger":"entrypoint","msg":"setting up manager"}
+{"level":"info","ts":1589406874.2192929,"logger":"entrypoint","msg":"Registering Components."}
+{"level":"info","ts":1589406874.219318,"logger":"entrypoint","msg":"setting up scheme"}
+{"level":"info","ts":1589406874.219448,"logger":"entrypoint","msg":"Setting up controller"}
+{"level":"info","ts":1589406874.2194738,"logger":"controller","msg":"Running controller in local mode, using kubeconfig file"}
+{"level":"info","ts":1589406874.224564,"logger":"controller","msg":"gang scheduling is set: ","gangscheduling":false}
+{"level":"info","ts":1589406874.2247412,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"xgboostjob-controller","source":"kind source: /, Kind="}
+{"level":"info","ts":1589406874.224958,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"xgboostjob-controller","source":"kind source: /, Kind="}
+{"level":"info","ts":1589406874.2251048,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"xgboostjob-controller","source":"kind source: /, Kind="}
+{"level":"info","ts":1589406874.225237,"logger":"entrypoint","msg":"setting up webhooks"}
+{"level":"info","ts":1589406874.225247,"logger":"entrypoint","msg":"Starting the Cmd."}
+{"level":"info","ts":1589406874.32791,"logger":"kubebuilder.controller","msg":"Starting Controller","controller":"xgboostjob-controller"}
+{"level":"info","ts":1589406874.430336,"logger":"kubebuilder.controller","msg":"Starting workers","controller":"xgboostjob-controller","worker count":1}
 ``` 
 ## Creating a XGBoost Training/Prediction Job
 

--- a/pkg/controller/xgboostjob/expectation.go
+++ b/pkg/controller/xgboostjob/expectation.go
@@ -55,12 +55,12 @@ func onDependentCreateFunc(r reconcile.Reconciler) func(event.CreateEvent) bool 
 		if !ok {
 			return true
 		}
-		logrus.Info("Update on create function ", xgbr.ControllerName(), " create object ", e.Meta.GetName())
 		rtype := e.Meta.GetLabels()[v1.ReplicaTypeLabel]
 		if len(rtype) == 0 {
 			return false
 		}
 
+		logrus.Info("Update on create function ", xgbr.ControllerName(), " create object ", e.Meta.GetName())
 		if controllerRef := metav1.GetControllerOf(e.Meta); controllerRef != nil {
 			expectKey := job_controller.GenExpectationPodsKey(e.Meta.GetNamespace()+"/"+controllerRef.Name, rtype)
 			xgbr.xgbJobController.Expectations.CreationObserved(expectKey)
@@ -79,12 +79,12 @@ func onDependentDeleteFunc(r reconcile.Reconciler) func(event.DeleteEvent) bool 
 			return true
 		}
 
-		logrus.Info("Update on deleting function ", xgbr.ControllerName(), " delete object ", e.Meta.GetName())
 		rtype := e.Meta.GetLabels()[v1.ReplicaTypeLabel]
 		if len(rtype) == 0 {
 			return false
 		}
 
+		logrus.Info("Update on deleting function ", xgbr.ControllerName(), " delete object ", e.Meta.GetName())
 		if controllerRef := metav1.GetControllerOf(e.Meta); controllerRef != nil {
 			expectKey := job_controller.GenExpectationPodsKey(e.Meta.GetNamespace()+"/"+controllerRef.Name, rtype)
 			xgbr.xgbJobController.Expectations.DeleteExpectations(expectKey)

--- a/pkg/controller/xgboostjob/xgboostjob_controller.go
+++ b/pkg/controller/xgboostjob/xgboostjob_controller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kubeflow/common/job_controller"
 	"github.com/kubeflow/common/job_controller/api/v1"
 	"github.com/kubeflow/xgboost-operator/pkg/apis/xgboostjob/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/sirupsen/logrus"
@@ -151,14 +150,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(&source.Kind{Type: &v1alpha1.XGBoostJob{}}, &handler.EnqueueRequestForObject{},
 		predicate.Funcs{CreateFunc: onOwnerCreateFunc(r)},
 	)
-	if err != nil {
-		return err
-	}
-
-	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &v1alpha1.XGBoostJob{},
-	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Remove watch for Deployment, xgboost CRD doesn’t use deployment, no need to watch it
2. Log create/update update logs only if pods has some replica labels
3. Update README.md with expected logs

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>