### PR TITLE
Set timeout for cloud build and upgrade goland version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.11.4 as builder
+FROM golang:1.12.17 as builder
 
 ENV GO111MODULE=on
 
@@ -8,7 +8,6 @@ WORKDIR /go/src/github.com/kubeflow/xgboost-operator
 
 COPY go.mod .
 COPY go.sum .
-# COPY vendor/ vendor/
 
 RUN go mod download
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -10,6 +10,7 @@ set -ex
 DOCKERFILE=$1
 CONTEXT_DIR=$(dirname "$DOCKERFILE")
 IMAGE=$2
+TIMEOUT=30m
 
 cd $CONTEXT_DIR
 TAG=$(git describe --tags --always --dirty)
@@ -17,5 +18,5 @@ TAG=$(git describe --tags --always --dirty)
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
 echo "Building ${IMAGE} using gcloud build"
-gcloud builds submit --tag=${IMAGE}:${TAG} --project=${GCP_PROJECT} .
+gcloud builds submit --tag=${IMAGE}:${TAG} --project=${GCP_PROJECT} --timeout=${TIMEOUT} .
 echo "Finished building ${IMAGE}:${TAG}"


### PR DESCRIPTION
This is to solve the build failure in https://github.com/kubeflow/xgboost-operator/pull/69
Kubernetes 1.15 has more staging folder and build is slower than 1.12. We need to set timeout explicitly. 

1. `gcloud build submit` by default has 10m timeout. If dependency is large or overlay is slow, it’s possible build timeout. Create a new argument with default 30m timeout

2. Remove vendor copy since it’s build on top of go modules

3. Upgrade Dockerfile golang version to match version in go.mod

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>