### PR TITLE
Fix Dockerfile for LightGBM example

### DIFF
--- a/config/samples/lightgbm-dist/Dockerfile
+++ b/config/samples/lightgbm-dist/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update && \
     gcc \
     g++ \
     git \
-    wget && \
+    curl && \
     # python environment
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    /bin/bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o conda.sh && \
+    /bin/bash conda.sh -f -b -p $CONDA_DIR && \
     export PATH="$CONDA_DIR/bin:$PATH" && \
     conda config --set always_yes yes --set changeps1 no && \
     # lightgbm
-    conda install -q -y numpy==1.19.1 scipy==1.5.2 scikit-learn==0.23.2 pandas==1.1.3 && \
+    conda install -q -y numpy scipy scikit-learn pandas && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     mkdir LightGBM/build && \
     cd LightGBM/build && \

--- a/config/samples/lightgbm-dist/Dockerfile
+++ b/config/samples/lightgbm-dist/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     export PATH="$CONDA_DIR/bin:$PATH" && \
     conda config --set always_yes yes --set changeps1 no && \
     # lightgbm
-    conda install -q -y numpy scipy scikit-learn pandas && \
+    conda install -q -y numpy==1.20.3 scipy==1.6.2 scikit-learn==0.24.2 pandas==1.3.0 && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     mkdir LightGBM/build && \
     cd LightGBM/build && \

--- a/config/samples/lightgbm-dist/README.md
+++ b/config/samples/lightgbm-dist/README.md
@@ -29,7 +29,7 @@ kind: XGBoostJob
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"xgboostjob.kubeflow.org/v1","kind":"XGBoostJob","metadata":{"annotations":{},"name":"lightgbm-dist-train-test","namespace":"default"},"spec":{"xgbReplicaSpecs":{"Master":{"replicas":1,"restartPolicy":"Never","template":{"apiVersion":"v1","kind":"Pod","spec":{"containers":[{"args":["--job_type=Train","--boosting_type=gbdt","--objective=binary","--metric=bnary_logloss,auc","--metric_freq=1","--is_training_metric=true","--max_bin=255","--data=data/binary.train","--valid_data=data/binary.test","--num_trees=100","--learning_rate=01","--num_leaves=63","--tree_learner=feature","--feature_fraction=0.8","--bagging_freq=5","--bagging_fraction=0.8","--min_data_in_leaf=50","--min_sum_hessian_in_leaf=50","--is_enable_sparse=true","--use_two_round_loading=false","--is_save_binary_file=false"],"image":"kubeflow/lightgbm-dist-py-test:1.0","imagePullPolicy":"Never","name":"xgboostjob","ports":[{"containerPort":9991,"name":"xgboostjob-port"}]}]}}},"Worker":{"replicas":2,"restartPolicy":"ExitCode","template":{"apiVersion":"v1","kind":"Pod","spec":{"containers":[{"args":["--job_type=Train","--boosting_type=gbdt","--objective=binary","--metric=bnary_logloss,auc","--metric_freq=1","--is_training_metric=true","--max_bin=255","--data=data/binary.train","--valid_data=data/binary.test","--num_trees=100","--learning_rate=01","--num_leaves=63","--tree_learner=feature","--feature_fraction=0.8","--bagging_freq=5","--bagging_fraction=0.8","--min_data_in_leaf=50","--min_sum_hessian_in_leaf=50","--is_enable_sparse=true","--use_two_round_loading=false","--is_save_binary_file=false"],"image":"kubeflow/lightgbm-dist-py-test:1.0","imagePullPolicy":"Never","name":"xgboostjob","ports":[{"containerPort":9991,"name":"xgboostjob-port"}]}]}}}}}}
+      {"apiVersion":"xgboostjob.kubeflow.org/v1","kind":"XGBoostJob","metadata":{"annotations":{},"name":"lightgbm-dist-train-test","namespace":"default"},"spec":{"xgbReplicaSpecs":{"Master":{"replicas":1,"restartPolicy":"Never","template":{"apiVersion":"v1","kind":"Pod","spec":{"containers":[{"args":["--job_type=Train","--boosting_type=gbdt","--objective=binary","--metric=binary_logloss,auc","--metric_freq=1","--is_training_metric=true","--max_bin=255","--data=data/binary.train","--valid_data=data/binary.test","--num_trees=100","--learning_rate=01","--num_leaves=63","--tree_learner=feature","--feature_fraction=0.8","--bagging_freq=5","--bagging_fraction=0.8","--min_data_in_leaf=50","--min_sum_hessian_in_leaf=50","--is_enable_sparse=true","--use_two_round_loading=false","--is_save_binary_file=false"],"image":"kubeflow/lightgbm-dist-py-test:1.0","imagePullPolicy":"Never","name":"xgboostjob","ports":[{"containerPort":9991,"name":"xgboostjob-port"}]}]}}},"Worker":{"replicas":2,"restartPolicy":"ExitCode","template":{"apiVersion":"v1","kind":"Pod","spec":{"containers":[{"args":["--job_type=Train","--boosting_type=gbdt","--objective=binary","--metric=binary_logloss,auc","--metric_freq=1","--is_training_metric=true","--max_bin=255","--data=data/binary.train","--valid_data=data/binary.test","--num_trees=100","--learning_rate=01","--num_leaves=63","--tree_learner=feature","--feature_fraction=0.8","--bagging_freq=5","--bagging_fraction=0.8","--min_data_in_leaf=50","--min_sum_hessian_in_leaf=50","--is_enable_sparse=true","--use_two_round_loading=false","--is_save_binary_file=false"],"image":"kubeflow/lightgbm-dist-py-test:1.0","imagePullPolicy":"Never","name":"xgboostjob","ports":[{"containerPort":9991,"name":"xgboostjob-port"}]}]}}}}}}
   creationTimestamp: "2020-10-14T15:31:23Z"
   generation: 7
   managedFields:
@@ -119,7 +119,7 @@ spec:
             - --job_type=Train
             - --boosting_type=gbdt
             - --objective=binary
-            - --metric=bnary_logloss,auc
+            - --metric=binary_logloss,auc
             - --metric_freq=1
             - --is_training_metric=true
             - --max_bin=255
@@ -156,7 +156,7 @@ spec:
             - --job_type=Train
             - --boosting_type=gbdt
             - --objective=binary
-            - --metric=bnary_logloss,auc
+            - --metric=binary_logloss,auc
             - --metric_freq=1
             - --is_training_metric=true
             - --max_bin=255

--- a/config/samples/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
+++ b/config/samples/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
@@ -20,7 +20,7 @@ spec:
               - --job_type=Train
               - --boosting_type=gbdt
               - --objective=binary
-              - --metric=bnary_logloss,auc
+              - --metric=binary_logloss,auc
               - --metric_freq=1
               - --is_training_metric=true
               - --max_bin=255
@@ -54,7 +54,7 @@ spec:
               - --job_type=Train
               - --boosting_type=gbdt
               - --objective=binary
-              - --metric=bnary_logloss,auc
+              - --metric=binary_logloss,auc
               - --metric_freq=1
               - --is_training_metric=true
               - --max_bin=255


### PR DESCRIPTION
I was unable to build the current Dockerfile for LightGBM sample.
It had some problems with `scikit-learn` version compatible.
Ref PRs: https://github.com/microsoft/LightGBM/pull/2637, https://github.com/microsoft/LightGBM/pull/2949.

I tried to be consistent with upstream Dockerfile.
Python: https://github.com/microsoft/LightGBM/blob/master/docker/dockerfile-python.
CLI: https://github.com/microsoft/LightGBM/blob/master/docker/dockerfile-cli.

Also, I fixed the metric name `binary_logloss`.

/assign @terrytangyuan @Jeffwan @gaocegege 